### PR TITLE
Ensure CSV-safe persistence for history and bookmarks

### DIFF
--- a/BookmarkManager .vb
+++ b/BookmarkManager .vb
@@ -1,4 +1,5 @@
 ﻿Imports System.IO
+Imports Microsoft.VisualBasic.FileIO
 
 Public Class BookmarkManager
     Public Shared bookmarkFilePath As String = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Temp\FBrowser\bookmarks.csv")
@@ -11,7 +12,12 @@ Public Class BookmarkManager
 
         ' Append bookmark to file
         Using writer As New StreamWriter(bookmarkFilePath, True)
-            writer.WriteLine($"{dateAdded},{title},{url}")
+            Dim fields = {
+                EscapeCsvField(dateAdded.ToString("o")),
+                EscapeCsvField(title),
+                EscapeCsvField(url)
+            }
+            writer.WriteLine(String.Join(",", fields))
         End Using
     End Sub
 
@@ -22,16 +28,16 @@ Public Class BookmarkManager
         EnsureDirectoryAndFileExist()
 
         ' Read bookmarks from file
-        Using reader As New StreamReader(bookmarkFilePath)
-            While Not reader.EndOfStream
-                Dim line As String = reader.ReadLine()
-                If Not String.IsNullOrEmpty(line) Then
-                    Dim data() As String = line.Split(","c)
-                    If data.Length = 3 Then
-                        Dim dateAdded As DateTime
-                        If DateTime.TryParse(data(0), dateAdded) Then
-                            bookmarkList.Add(New BookmarkItem(data(2), data(1), dateAdded))
-                        End If
+        Using parser As New TextFieldParser(bookmarkFilePath)
+            parser.SetDelimiters(",")
+            parser.HasFieldsEnclosedInQuotes = True
+
+            While Not parser.EndOfData
+                Dim data() As String = parser.ReadFields()
+                If data IsNot Nothing AndAlso data.Length = 3 Then
+                    Dim dateAdded As DateTime
+                    If DateTime.TryParse(data(0), dateAdded) Then
+                        bookmarkList.Add(New BookmarkItem(data(2), data(1), dateAdded))
                     End If
                 End If
             End While
@@ -50,4 +56,12 @@ Public Class BookmarkManager
             File.Create(bookmarkFilePath).Dispose()
         End If
     End Sub
+    
+    Private Shared Function EscapeCsvField(value As String) As String
+        If value Is Nothing Then
+            value = String.Empty
+        End If
+
+        Return """" & value.Replace("""", """"") & """"
+    End Function
 End Class


### PR DESCRIPTION
## Summary
- quote and escape CSV fields when persisting browser history and bookmarks
- parse saved CSV using TextFieldParser so titles with commas/quotes are handled safely

## Testing
- Not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68dbb6f2b0648323962347232cca23ac